### PR TITLE
removed string constructor and formatter for Date Only fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.quickfixj.orchestra</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Parent project for FIX Orchestra / QuickFIX integration</description>

--- a/quickfixj-from-fix-orchestra-repository/pom.xml
+++ b/quickfixj-from-fix-orchestra-repository/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.quickfixj.orchestra</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quickfixj-from-fix-orchestra</artifactId>

--- a/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-code-generator-maven-plugin/pom.xml
+++ b/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-code-generator-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.quickfixj.orchestra</groupId>
 		<artifactId>quickfixj-from-fix-orchestra</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quickfixj-from-fix-orchestra-code-generator-maven-plugin</artifactId>

--- a/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-dictionary-generator-maven-plugin/pom.xml
+++ b/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-dictionary-generator-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.quickfixj.orchestra</groupId>
 		<artifactId>quickfixj-from-fix-orchestra</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>quickfixj-from-fix-orchestra-dictionary-generator-maven-plugin</artifactId>

--- a/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/pom.xml
+++ b/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.quickfixj.orchestra</groupId>
 		<artifactId>quickfixj-from-fix-orchestra</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 	
 	<artifactId>quickfixj-from-fix-orchestra-generator</artifactId>

--- a/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/src/main/java/org/quickfixj/orchestra/CodeGeneratorJ.java
+++ b/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/src/main/java/org/quickfixj/orchestra/CodeGeneratorJ.java
@@ -855,9 +855,6 @@ public class CodeGeneratorJ {
 		case "UtcDateOnlyField":
 			writer.write(String.format("%n%spublic %s(LocalDate data) {%n%ssuper(%d, data);%n%s}%n", CodeGeneratorUtil.indent(1),
 					className, CodeGeneratorUtil.indent(2), fieldId, CodeGeneratorUtil.indent(1)));
-			// added for compatibility with existing QFJ tests
-			writer.write(String.format("%n%spublic %s(String data) {%n%ssuper(%d, data);%n%s}%n", CodeGeneratorUtil.indent(1), className,
-					CodeGeneratorUtil.indent(2), fieldId, CodeGeneratorUtil.indent(1)));
 			break;
 		case "UtcTimeOnlyField":
 			writer.write(String.format("%n%spublic %s(LocalTime data) {%n%ssuper(%d, data);%n%s}%n", CodeGeneratorUtil.indent(1),


### PR DESCRIPTION
These changes are to revert the generation of a new String constructor for Fields derived from UTCLocalDate