### PR TITLE
Generate header related methods in `Message` class.

### DIFF
--- a/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/src/main/java/org/quickfixj/orchestra/CodeGeneratorJ.java
+++ b/quickfixj-from-fix-orchestra-repository/quickfixj-from-fix-orchestra-generator/src/main/java/org/quickfixj/orchestra/CodeGeneratorJ.java
@@ -568,6 +568,7 @@ public class CodeGeneratorJ {
 			writeSerializationVersion(writer, SERIALIZATION_VERSION);
 			writeMessageNoArgBaseConstructor(writer, "Message");
 			writeProtectedMessageBaseConstructor(writer, "Message", getBeginString(version));
+            writeHeaderMethods(writer);
 			writeMessageDerivedHeaderClass(writer);
 
 			writeEndClassDeclaration(writer);
@@ -1095,6 +1096,27 @@ public class CodeGeneratorJ {
 
 		return writer;
 	}
+
+    private static void writeHeaderMethods(FileWriter writer) throws IOException {
+        writeHeaderFactoryMethod(writer);
+        writeHeaderGetter(writer);
+    }
+
+    private static void writeHeaderFactoryMethod(FileWriter writer) throws IOException {
+        writer.write(String.format("%n"));
+        writer.write(String.format("%s@Override%n", CodeGeneratorUtil.indent(1)));
+        writer.write(String.format("%sprotected Header newHeader() {%n", CodeGeneratorUtil.indent(1)));
+        writer.write(String.format("%sreturn new Header(this);%n", CodeGeneratorUtil.indent(2)));
+        writer.write(String.format("%s}%n", CodeGeneratorUtil.indent(1)));
+    }
+
+    private static void writeHeaderGetter(FileWriter writer) throws IOException {
+        writer.write(String.format("%n"));
+        writer.write(String.format("%s@Override%n", CodeGeneratorUtil.indent(1)));
+        writer.write(String.format("%spublic Header getHeader() {%n", CodeGeneratorUtil.indent(1)));
+        writer.write(String.format("%sreturn (Message.Header)header;%n", CodeGeneratorUtil.indent(2)));
+        writer.write(String.format("%s}%n", CodeGeneratorUtil.indent(1)));
+    }
 
 	private static Writer writeMessageDerivedHeaderClass(Writer writer) throws IOException {
 		writeStaticClassDeclaration(writer, "Header", "quickfix.Message.Header");


### PR DESCRIPTION
`newHeader()` and `getHeader()` methods will be generated in the Message class. This will help keeping consitent header behavior across all fix versions.

See

- https://github.com/quickfix-j/quickfixj/issues/801
- https://github.com/quickfix-j/quickfixj/pull/1048

The new classes will look like this.

```
/* Generated Java Source File */
package quickfix.fixlatest;
import quickfix.field.*;

public class Message extends quickfix.Message {
  static final long serialVersionUID = 552892318L;

  public Message() {
    this(null);
  }
  protected Message(int[] fieldOrder) {
    super(fieldOrder);
    header = new Header(this);
    trailer = new Trailer();
    getHeader().setField(new BeginString("FIXT.1.1"));
  }

  @Override
  protected Header newHeader() {
    return new Header(this);
  }

  @Override
  public Header getHeader() {
    return (Message.Header)header;
  }

public static class Header extends quickfix.Message.Header {
  static final long serialVersionUID = 552892318L;

  public Header(Message msg) {

  }
}
}

```