### PR TITLE
Update macOS and JDK distribution for CI job

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-13, windows-latest]
+        os: [ubuntu-latest, macOS-14, windows-latest]
         java: [8, 11, 17]
       fail-fast: false
       max-parallel: 4
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          distribution: 'temurin'
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
       - name: Test with Maven
         env:


### PR DESCRIPTION
Corretto has JDK8 build on macOS